### PR TITLE
The chilrenOnly option is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ function hooks (morphdom) {
       onNodeDiscarded: function (node) {
         if (callable(node.ondiscard)) node.ondiscard(node)
         if (callable(opts.onNodeDiscarded)) opts.onNodeDiscarded(node)
-      }
+      },
+      
+      childrenOnly: opts.childrenOnly
     })
   }
 }


### PR DESCRIPTION
Hello, while testing the module, I noticed the chilrenOnly property in the options was missing.

Simply passing it along seems to fix it!

Cheers
